### PR TITLE
Add linux-headers to Alpine build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN cd SoftEtherVPN &&\
 	git submodule init &&\
 	git submodule update &&\
         ./configure $TARGET_CONFIG_FLAGS &&\
-	make -C build
+	make -j $(getconf _NPROCESSORS_ONLN) -C build
 
 FROM alpine
 RUN apk add --no-cache readline \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine AS builder
 RUN mkdir /usr/local/src && apk add binutils --no-cache\
-        build-base \
+        linux-headers \
+	build-base \
         readline-dev \
         openssl-dev \
         ncurses-dev \


### PR DESCRIPTION
See https://github.com/SoftEtherVPN/SoftEtherVPN/issues/2054

This PR fixes that issue by adding the ```linux-headers``` package (which provides the missing header), and a minor improvement to improve build performance by using [```getconf _NPROCESSORS_ONLN```](https://stackoverflow.com/questions/19619582/number-of-processors-cores-in-command-line) to get the number of cpu cores and add multithreading to the build process.